### PR TITLE
Alarm nodes in PV widgets…

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.diirt.datasource/src/org/csstudio/alarm/diirt/datasource/BeastDataSource.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.diirt.datasource/src/org/csstudio/alarm/diirt/datasource/BeastDataSource.java
@@ -91,7 +91,7 @@ public class BeastDataSource extends DataSource {
                                 // TODO Auto-generated method stub
                             }
 
-                            @SuppressWarnings("rawtypes")
+                            @SuppressWarnings({ "rawtypes", "unchecked" })
                             @Override
                             public void newAlarmState(AlarmClientModel model, AlarmTreePV pv, boolean parent_changed) {
                                 log.fine("newAlarmState");
@@ -152,7 +152,6 @@ public class BeastDataSource extends DataSource {
     @Override
     protected ChannelHandler createChannel(String channelName) {
         return new BeastChannelHandler(channelName, this);
-        
     }
 
     @Override
@@ -160,24 +159,46 @@ public class BeastDataSource extends DataSource {
         super.close();
         model.release();
     }
+    
+    /* (non-Javadoc)
+     * Override of default channelHandlerLookupName.
+     * This implementation makes a leading and trailing "/" optional.
+     * All four of these will resolve to the same channel: "/demo/test/", "/demo/test", "demo/test/" & "demo/test".
+     * 
+	 * @see org.diirt.datasource.DataSource#channelHandlerLookupName(java.lang.String)
+	 */
+	@Override
+	protected String channelHandlerLookupName(String channelName) {
+		String channel = channelName;
+    	if (channel != null && channel != "/") {
+    		if (channel.endsWith("/"))
+    			channel = channel.substring(0, channel.length()-1);
+    		if (channel.startsWith("/"))
+    			channel = channel.substring(1);
+		}
 
-    public BeastTypeSupport getTypeSupport() {
+    	return channel;
+	}
+
+	public BeastTypeSupport getTypeSupport() {
         return typeSupport;
     }
 
     protected void add(String channelName, Consumer beastChannelHandler){
+    	String beastChannel = channelHandlerLookupName(channelName);
         synchronized (map) {
-            if (!map.containsKey(channelName) || map.get(channelName) == null) {
-                map.put(channelName, new ArrayList<Consumer>());
+            if (!map.containsKey(beastChannel) || map.get(beastChannel) == null) {
+                map.put(beastChannel, new ArrayList<Consumer>());
             }
-            map.get(channelName).add(beastChannelHandler);
+            map.get(beastChannel).add(beastChannelHandler);
         }
     }
 
     protected void remove(String channelName, Consumer beastChannelHandler) {
+    	String beastChannel = channelHandlerLookupName(channelName);
         synchronized (map) {
-            if (map.containsKey(channelName)) {
-                map.get(channelName).remove(beastChannelHandler);
+            if (map.containsKey(beastChannel)) {
+                map.get(beastChannel).remove(beastChannelHandler);
             }
         }
     }

--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.diirt.datasource/src/org/csstudio/alarm/diirt/datasource/BeastDataSource.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.diirt.datasource/src/org/csstudio/alarm/diirt/datasource/BeastDataSource.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -21,7 +20,6 @@ import java.util.logging.Logger;
 
 import org.csstudio.alarm.beast.client.AlarmTreeItem;
 import org.csstudio.alarm.beast.client.AlarmTreePV;
-import org.csstudio.alarm.beast.client.AlarmTreeRoot;
 import org.csstudio.alarm.beast.ui.clientmodel.AlarmClientModel;
 import org.csstudio.alarm.beast.ui.clientmodel.AlarmClientModelListener;
 import org.diirt.datasource.ChannelHandler;
@@ -59,13 +57,12 @@ public class BeastDataSource extends DataSource {
         super(true);
 
         typeSupport = new BeastTypeSupport();
-        
+
         try {
 
             // Create an instance to the AlarmClientModel
             final CompletableFuture<Void> future = CompletableFuture
-                    .supplyAsync(() -> initialize(configuration), executor)
-                    .thenAccept((model) -> {
+                    .supplyAsync(() -> initialize(configuration), executor).thenAccept((model) -> {
                         this.model = model;
                         this.model.addListener(new AlarmClientModelListener() {
 
@@ -85,9 +82,7 @@ public class BeastDataSource extends DataSource {
                             }
 
                             @Override
-                            public void serverModeUpdate(
-                                    AlarmClientModel model,
-                                    boolean maintenance_mode) {
+                            public void serverModeUpdate(AlarmClientModel model, boolean maintenance_mode) {
                                 // TODO Auto-generated method stub
                             }
 
@@ -110,7 +105,7 @@ public class BeastDataSource extends DataSource {
                                         }
                                     }
                                     // Notify all parent nodes if parent changed
-                                    if(parent_changed){
+                                    if (parent_changed) {
                                         AlarmTreeItem parent = pv.getParent();
                                         while (parent != null) {
                                             List<Consumer> parentHandlers = map.get(parent.getPathName().substring(1));
@@ -119,7 +114,7 @@ public class BeastDataSource extends DataSource {
                                                     try {
                                                         consumer.accept(getState(parent.getPathName()));
                                                     } catch (Exception e) {
-                                                        
+
                                                     }
                                                 }
                                             }
@@ -140,7 +135,7 @@ public class BeastDataSource extends DataSource {
         try {
             if (configuration.getConfigName() != null && !configuration.getConfigName().isEmpty()) {
                 alarmModel = AlarmClientModel.getInstance(configuration.getConfigName());
-            } else{
+            } else {
                 alarmModel = AlarmClientModel.getInstance();
             }
             return alarmModel;
@@ -159,43 +154,49 @@ public class BeastDataSource extends DataSource {
         super.close();
         model.release();
     }
-    
-    /* (non-Javadoc)
-     * Override of default channelHandlerLookupName.
+
+    /*
+     * (non-Javadoc) Override of default channelHandlerLookupName.
      * This implementation makes a leading and trailing "/" optional.
-     * All four of these will resolve to the same channel: "/demo/test/", "/demo/test", "demo/test/" & "demo/test".
-     * 
-	 * @see org.diirt.datasource.DataSource#channelHandlerLookupName(java.lang.String)
-	 */
-	@Override
-	protected String channelHandlerLookupName(String channelName) {
-		String channel = channelName;
-    	if (channel != null && channel != "/") {
-    		if (channel.endsWith("/"))
-    			channel = channel.substring(0, channel.length()-1);
-    		if (channel.startsWith("/"))
-    			channel = channel.substring(1);
-		}
+     * All four of these will resolve to the same channel:
+     * "/demo/test/", "/demo/test", "demo/test/" & "demo/test".
+     *
+     * @see org.diirt.datasource.DataSource#channelHandlerLookupName(java.lang.
+     * String)
+     */
+    @Override
+    protected String channelHandlerLookupName(String channelName) {
+        String channel = channelName;
+        if (channel != null && !channel.equals("/") && channel.length() > 0) {
+            if (channel.length() > 0 && channel.charAt(channel.length() - 1) == '/')
+                channel = channel.substring(0, channel.length() - 1);
+            if (channel.length() > 0 && channel.charAt(0) == '/')
+                channel = channel.substring(1);
+        }
 
-    	return channel;
-	}
+        return channel;
+    }
 
-	public BeastTypeSupport getTypeSupport() {
+    public BeastTypeSupport getTypeSupport() {
         return typeSupport;
     }
 
-    protected void add(String channelName, Consumer beastChannelHandler){
-    	String beastChannel = channelHandlerLookupName(channelName);
+    @SuppressWarnings("rawtypes")
+    protected void add(String channelName, Consumer beastChannelHandler) {
+        String beastChannel = channelHandlerLookupName(channelName);
         synchronized (map) {
-            if (!map.containsKey(beastChannel) || map.get(beastChannel) == null) {
-                map.put(beastChannel, new ArrayList<Consumer>());
+            List<Consumer> list = map.get(beastChannel);
+            if (list == null) {
+                list = new ArrayList<Consumer>();
+                map.put(beastChannel, list);
             }
-            map.get(beastChannel).add(beastChannelHandler);
+            list.add(beastChannelHandler);
         }
     }
 
+    @SuppressWarnings("rawtypes")
     protected void remove(String channelName, Consumer beastChannelHandler) {
-    	String beastChannel = channelHandlerLookupName(channelName);
+        String beastChannel = channelHandlerLookupName(channelName);
         synchronized (map) {
             if (map.containsKey(beastChannel)) {
                 map.get(beastChannel).remove(beastChannelHandler);
@@ -228,52 +229,51 @@ public class BeastDataSource extends DataSource {
         }
     }
 
-    protected boolean isWriteAllowed(){
+    protected boolean isWriteAllowed() {
         if (model != null) {
             return model.isWriteAllowed();
         } else {
             return false;
         }
     }
-    
-    protected void acknowledge(String channelName, boolean acknowledge) throws Exception{
+
+    protected void acknowledge(String channelName, boolean acknowledge) throws Exception {
         getState(channelName).acknowledge(acknowledge);
     }
 
-    // implementing the enable disable mechanism using the example of the DisableComponentAction
+    // implementing the enable disable mechanism using the example of the
+    // DisableComponentAction
     protected void enable(String channelName, boolean enable) throws Exception {
         AlarmTreeItem item = getState(channelName);
         List<AlarmTreePV> pvs = new ArrayList<AlarmTreePV>();
-        final CompletableFuture<Void> future = CompletableFuture
-                .runAsync(() -> addPVs(pvs, item, enable), executor)
+        final CompletableFuture<Void> future = CompletableFuture.runAsync(() -> addPVs(pvs, item, enable), executor)
                 .thenRun(() -> {
                     for (AlarmTreePV alarmTreePV : pvs) {
                         try {
                             model.enable(alarmTreePV, enable);
                         } catch (Exception e) {
-                            //TODO handle raising the write exception
+                            // TODO handle raising the write exception
                             e.printStackTrace();
                             new Exception("Failed to enable/disable : " + ((AlarmTreePV) item).getName(), e);
                         }
                     }
                 });
     }
-    
-    /** @param pvs List where PVs to enable/disable will be added
-     *  @param item Item for which to locate PVs, recursively
+
+    /**
+     * @param pvs
+     *            List where PVs to enable/disable will be added
+     * @param item
+     *            Item for which to locate PVs, recursively
      */
-    protected void addPVs(final List<AlarmTreePV> pvs, final AlarmTreeItem item, boolean enable)
-    {
-        if (item instanceof AlarmTreePV)
-        {
+    protected void addPVs(final List<AlarmTreePV> pvs, final AlarmTreeItem item, boolean enable) {
+        if (item instanceof AlarmTreePV) {
             final AlarmTreePV pv = (AlarmTreePV) item;
             if (pv.isEnabled() != enable)
                 pvs.add(pv);
-        }
-        else
-        {
+        } else {
             final int N = item.getChildCount();
-            for (int i=0; i<N; ++i)
+            for (int i = 0; i < N; ++i)
                 addPVs(pvs, item.getChild(i), enable);
         }
     }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/PVWidgetEditpartDelegate.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/PVWidgetEditpartDelegate.java
@@ -5,13 +5,11 @@ import static org.diirt.util.time.TimeDuration.ofMillis;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.WeakHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -67,9 +65,7 @@ import org.diirt.vtype.VTable;
 import org.diirt.vtype.VType;
 
 public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
-    //    private interface AlarmSeverity extends ISeverity{
-    //        public void copy(ISeverity severity);
-    //    }
+
     private final class WidgetPVListener extends IPVListener.Stub{
         private String pvPropID;
         private boolean isControlPV;
@@ -127,7 +123,7 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
         }
     };
 
-    private static final Logger log = Logger.getLogger("BeastDataSource TESTING");
+    private static final Logger log = Logger.getLogger("BeastDataSource");
 
     private int updateSuppressTime = 1000;
     private String controlPVPropId = null;
@@ -190,7 +186,7 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
     		return isBeastAlarm && beastInfo.isBeastChannelConnected() && beastInfo.latchedSeverity != BeastAlarmSeverityLevel.OK;
     	}
     }
-    
+
     /**Returns true when the operator should ACK an alarm:<br>
      * - PV is currently in an alarm state<br>
      * - PV was not acknowledged (latched severity is also active)
@@ -248,6 +244,12 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
                         ((String)sp.getPropertyValue()).trim().length() <=0)
                     continue;
 
+                if (((String) sp.getPropertyValue()).toLowerCase().startsWith("beast://")) {
+                    // prevent BeastDataSource channels to be configured as PVs
+                    // if a Beast channel is set as PV, it will only provide Alarm Sensitivity functionality, not values etc.
+                	continue;
+                }
+                
                 try {
                     IPV pv = BOYPVFactory.createPV((String) sp.getPropertyValue(),
                             isAllValuesBuffered);
@@ -267,13 +269,13 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
     public boolean acknowledgeAlarm() {
     	synchronized (beastInfo) {
 	        if (!beastInfo.isBeastChannelConnected() || beastInfo.isLatchedAlarmOK() || alarmPV == null) return false;
-	
+
 	        if (!beastInfo.isAcknowledged())
 	            alarmPV.write("ack");
 	        else
 	            alarmPV.write("unack");
     	}
-    	
+
         return true;
     }
 
@@ -316,48 +318,47 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
             return;
         }
 
-        log.info("Starting BeastAlarmListener for channel " + alarmPVName);
+//        log.fine("Starting BeastAlarmListener for channel " + alarmPVName);
         beastInfo.setBeastChannelName(alarmPVName);
         PVWidgetEditpartDelegate pvWidget = this;
 
         DesiredRateReadWriteExpression<?,Object> expr = formula(alarmPVName);
         alarmPV = PVManager
                 .readAndWrite(expr)
-                .timeout(ofMillis(3000))
+                .timeout(ofMillis(10000))
                 .notifyOn(swtThread(editpart.getViewer().getControl().getDisplay()))
                 .readListener(new PVReaderListener<Object>() {
                     @SuppressWarnings("unchecked")
                     @Override
                     public void pvChanged(PVReaderEvent<Object> event) {
                     	String pvName = pvWidget.getWidgetModel().getPVName();
-                    	
-                        log.fine("BeastAlarmListener (" + pvName + ") received a new event of type " + event.toString());
+
                         if (event.isExceptionChanged()) {
                             Exception e = event.getPvReader().lastException();
-                            log.severe("BeastAlarmListener (" + pvName + ") received an EXCEPTION: " + e.toString());
+                            log.fine("BeastAlarmListener (" + pvName + ") received an EXCEPTION: " + e.toString());
                             e.printStackTrace();
                         }
 
-                        // if we receive a ValueChanged event we know we're connected even if we never received the ConnectionChanged event
+                        // if we receive a ValueChanged event we know we're connected even if we
+                        // never received the ConnectionChanged event (with isConnected being true)
                         if (event.isConnectionChanged() || (!beastInfo.isBeastChannelConnected() && event.isValueChanged())) {
-//                    	if (event.isConnectionChanged()) {
                         	boolean connected = event.getPvReader().isConnected();
-                        	
-                    		// TODO: remove this check when Kunal adds "connection awareness" to BeastDataSource, or leave it in as a failsafe ?
+
+                    		// TODO: remove this check when Kunal adds "connection awareness" to BeastDataSource,
+                        	// or leave it in as a failsafe ?
                             if (!connected && event.isValueChanged()) {
-                                // the PVReader says we're not connected but we received a VAL event !
-                                log.fine("BeastAlarmListener (" + pvName + "): VAL event received, but PVReader says it's not connected to BEAST ! (forcing connection state to TRUE)");
+                                // the PVReader says it's not connected but we received a VAL event !
                                 connected = true; // force to TRUE since we received a ValueChanged event..
                             }
-                        	
+
                         	synchronized(beastInfo) {
                                 // isBeastAlarm will be true only if we successfully connected to it at least once
                         		beastInfo.setBeastChannelConnected(connected);
                                 isBeastAlarm |= beastInfo.isBeastChannelConnected();
                         	}
                         }
-
                         if (!event.isValueChanged()) return;
+                        
                         if (!(event.getPvReader().getValue() instanceof VTable)) {
                             log.severe("BeastAlarmListener (" + pvName + "): data is not a VTable");
                             return;
@@ -388,16 +389,26 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
                         synchronized (beastInfo) {
                             beastInfo.latchedSeverity = BeastAlarmSeverityLevel.parse(data.get(latchedSeverityIdx));
                             beastInfo.currentSeverity = BeastAlarmSeverityLevel.parse(data.get(currentSeverityIdx));
-                            log.fine(pvName + " received: Latched = " + beastInfo.latchedSeverity.getDisplayName() + " | current = " + beastInfo.currentSeverity.getDisplayName());
+                        }
+
+                        AlarmSeverity beastSeverity = beastInfo.currentSeverity.getAlarmSeverity();
+                        boolean fireEvent = false;
+                        if (alarmSeverity != beastSeverity) {
+                            alarmSeverity = beastSeverity;
+                            fireEvent = true;
                         }
 
                         // The widget will Blink only when the PV is currently in alarm and has not yet been acknowledged
                         if (pvWidget.isBeastAlarmAndConnected() && pvWidget.isBeastAlarmActiveUnack()) {
-                            if (!WidgetBlinker.INSTANCE.isBlinking(pvWidget)) WidgetBlinker.INSTANCE.add(pvWidget);
+                            if (!WidgetBlinker.INSTANCE.isBlinking(pvWidget))
+                                WidgetBlinker.INSTANCE.add(pvWidget);
                         } else if (WidgetBlinker.INSTANCE.isBlinking(pvWidget)) {
                             WidgetBlinker.INSTANCE.remove(pvWidget);
+                            fireEvent = false; // because resetBeastBlink() will fire it, no need to do it twice
                             pvWidget.resetBeastBlink();
                         }
+
+                        if (fireEvent) fireAlarmSeverityChanged(beastSeverity, pvWidget.editpart.getFigure());
                     }
                 })
                 .asynchWriteAndMaxReadRate(TimeDuration.ofHertz(25));
@@ -432,7 +443,7 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
             pvsHaveBeenStarted = false;
         }
 
-        // disconnect the AlarmPV beast listener and attempt removal from beast blinking list 
+        // disconnect the AlarmPV beast listener and attempt removal from beast blinking list
         if (alarmPV != null) {
             alarmPV.close();
             alarmPV = null;
@@ -658,7 +669,7 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
                 }
                 pvMap.remove(pvNamePropID);
                 String newPVName = ((String)newValue).trim();
-                if(newPVName.length() <= 0)
+                if(newPVName.length() <= 0 || newPVName.toLowerCase().startsWith("beast://"))
                     return false;
                 try {
                     lastWriteAccess = null;
@@ -825,7 +836,7 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
                     borderSeverity = AlarmSeverity.NONE;
                 }
             }
-            
+
             switch (borderSeverity) {
             case NONE:
                 if(editpart.getWidgetModel().getBorderStyle() == BorderStyle.NONE)

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/PVWidgetEditpartDelegate.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/PVWidgetEditpartDelegate.java
@@ -42,6 +42,15 @@ import org.csstudio.simplepv.IPVListener;
 import org.csstudio.simplepv.VTypeHelper;
 import org.csstudio.ui.util.CustomMediaFactory;
 import org.csstudio.ui.util.thread.UIBundlingThread;
+import org.diirt.datasource.PV;
+import org.diirt.datasource.PVManager;
+import org.diirt.datasource.PVReaderEvent;
+import org.diirt.datasource.PVReaderListener;
+import org.diirt.datasource.expression.DesiredRateReadWriteExpression;
+import org.diirt.util.time.TimeDuration;
+import org.diirt.vtype.AlarmSeverity;
+import org.diirt.vtype.VTable;
+import org.diirt.vtype.VType;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.draw2d.AbstractBorder;
 import org.eclipse.draw2d.Border;
@@ -54,15 +63,6 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
-import org.diirt.datasource.PV;
-import org.diirt.datasource.PVManager;
-import org.diirt.datasource.PVReaderEvent;
-import org.diirt.datasource.PVReaderListener;
-import org.diirt.datasource.expression.DesiredRateReadWriteExpression;
-import org.diirt.util.time.TimeDuration;
-import org.diirt.vtype.AlarmSeverity;
-import org.diirt.vtype.VTable;
-import org.diirt.vtype.VType;
 
 public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
 
@@ -223,8 +223,6 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
                 try {
                     if (!display.isDisposed())
                         display.asyncExec(task);
-                    else
-                        Logger.getLogger("BeastDataSource TESTING").severe("Display is DISPOSED");
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -249,7 +247,7 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
                     // if a Beast channel is set as PV, it will only provide Alarm Sensitivity functionality, not values etc.
                 	continue;
                 }
-                
+
                 try {
                     IPV pv = BOYPVFactory.createPV((String) sp.getPropertyValue(),
                             isAllValuesBuffered);
@@ -358,7 +356,7 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
                         	}
                         }
                         if (!event.isValueChanged()) return;
-                        
+
                         if (!(event.getPvReader().getValue() instanceof VTable)) {
                             log.severe("BeastAlarmListener (" + pvName + "): data is not a VTable");
                             return;


### PR DESCRIPTION
don't register PV Listeners for beast protocol "PVs", use both EPICS & BEAST current severity to drive alarm-sensitive properties (border/front/back color);
BeastDataSource: allow optional leading/trailing "/" in PV (node) path (event dispatcher assumes no leading or trailing "/")
