### PR TITLE
BEAST acknowledgment submenu

### DIFF
--- a/applications/alarm/alarm-plugins/org.csstudio.alarm.diirt.datasource/src/org/csstudio/alarm/diirt/datasource/BeastDataSource.java
+++ b/applications/alarm/alarm-plugins/org.csstudio.alarm.diirt.datasource/src/org/csstudio/alarm/diirt/datasource/BeastDataSource.java
@@ -168,7 +168,7 @@ public class BeastDataSource extends DataSource {
     protected String channelHandlerLookupName(String channelName) {
         String channel = channelName;
         if (channel != null && !channel.equals("/") && channel.length() > 0) {
-            if (channel.length() > 0 && channel.charAt(channel.length() - 1) == '/')
+            if (channel.charAt(channel.length() - 1) == '/')
                 channel = channel.substring(0, channel.length() - 1);
             if (channel.length() > 0 && channel.charAt(0) == '/')
                 channel = channel.substring(1);

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/plugin.xml
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/plugin.xml
@@ -157,15 +157,8 @@
       </objectContribution>
       <objectContribution
             adaptable="false"
-            id="org.csstudio.opibuilder.acknowledgeAlarm"
+            id="org.csstudio.opibuilder.beastAlarmPopupMenu"
             objectClass="org.csstudio.opibuilder.editparts.AbstractPVWidgetEditPart">
-         <action
-               class="org.csstudio.opibuilder.actions.AcknowledgeAlarmAction"
-               enablesFor="1"
-               id="org.csstudio.opibuilder.acknowledgeAlarmAction"
-               label="Acknowledge Alarm"
-               tooltip="If the widget is connected to a BEAST AlarmPV, acknowledges/unacknowledges this PV's alarm">
-         </action>
          <visibility>
             <and>
                <objectState
@@ -178,6 +171,20 @@
                </objectState>
             </and>
          </visibility>
+         <menu
+             id="org.csstudio.opibuilder.beastSubMenu"
+             label="BEAST Alarm"
+             path="beastsub">
+             <separator name="beastsub1"/>
+         </menu>
+         <action
+               id="org.csstudio.opibuilder.acknowledgeAlarmAction"
+               class="org.csstudio.opibuilder.actions.AcknowledgeAlarmAction"
+               menubarPath="org.csstudio.opibuilder.beastSubMenu/beastsub1"
+               label="Acknowledge Alarm"
+               tooltip="If the widget is connected to a BEAST AlarmPV, acknowledges/unacknowledges this PV's alarm"
+               enablesFor="1">
+         </action>
       </objectContribution>      
       <objectContribution
             adaptable="true"

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/AcknowledgeAlarmAction.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/actions/AcknowledgeAlarmAction.java
@@ -28,25 +28,25 @@ public class AcknowledgeAlarmAction implements IObjectActionDelegate {
 	@Override
 	public void run(IAction action) {
         final AbstractBaseEditPart selectedWidget = getSelectedWidget();
-        
+
 		if(selectedWidget == null || selectedWidget.getWidgetModel() == null) return;
         if (!(selectedWidget.getWidgetModel() instanceof IPVWidgetModel) || !(selectedWidget instanceof AbstractPVWidgetEditPart)) return;
-        
+
 //        IPVWidgetModel model = (IPVWidgetModel) selectedWidget.getWidgetModel();
-        
+
         PVWidgetEditpartDelegate pvDelegate = ((AbstractPVWidgetEditPart) selectedWidget).getPVWidgetEditpartDelegate();
         if (pvDelegate.isBeastAlarmAndConnected() == false) return;
-        
+
         pvDelegate.acknowledgeAlarm();
 //        MessageDialog.openInformation(null, "Acknowledge PV", "When implemented, this will acknowledge AlarmPV ");
 	}
 
 	private void updateAction(IAction action) {
         final AbstractBaseEditPart selectedWidget = getSelectedWidget();
-        
+
 		if(selectedWidget == null || selectedWidget.getWidgetModel() == null) return;
         if (!(selectedWidget.getWidgetModel() instanceof IPVWidgetModel) || !(selectedWidget instanceof AbstractPVWidgetEditPart)) return;
-        
+
         IPVWidgetModel model = (IPVWidgetModel) selectedWidget.getWidgetModel();
         PVWidgetEditpartDelegate pvDelegate = ((AbstractPVWidgetEditPart) selectedWidget).getPVWidgetEditpartDelegate();
 
@@ -54,11 +54,11 @@ public class AcknowledgeAlarmAction implements IObjectActionDelegate {
         	// cannot ack/unack
         	action.setEnabled(false);
         	action.setImageDescriptor(null);
-        	action.setText("Cannot ACK - not connected to BEAST");
+        	action.setText("Cannot ACK - not connected");
         	action.setToolTipText("");
         	return;
         }
-        
+
         if (pvDelegate.getBeastAlarmInfo().isLatchedAlarmOK()) {
         	action.setEnabled(false);
         }
@@ -67,11 +67,12 @@ public class AcknowledgeAlarmAction implements IObjectActionDelegate {
     	action.setImageDescriptor(getImageDescriptor(pvDelegate.getBeastAlarmInfo().currentSeverity, pvDelegate.getBeastAlarmInfo().latchedSeverity));
     	action.setToolTipText("Test tooltip:\nLatched Severity: " + pvDelegate.getBeastAlarmInfo().latchedSeverity.getDisplayName()
     			+ "\nCurrent Severity: " + pvDelegate.getBeastAlarmInfo().currentSeverity.getDisplayName());
-    	if (pvDelegate.getBeastAlarmInfo().isAcknowledged()) {
-            action.setText("Un-Acknowledge alarm on " + model.getPVName());
-        } else {
-            action.setText("Acknowledge alarm on " + model.getPVName());
-    	}
+
+    	String actionDesc = String.format("%1$sAcknowledge %2$s: %3$s",
+    	        pvDelegate.getBeastAlarmInfo().isAcknowledged() ? "Un-" : "",
+    	        pvDelegate.isBeastAlarmNode() ? "NODE" : "PV",
+                pvDelegate.getBeastAlarmInfo().getBeastChannelNameNoScheme());
+    	action.setText(actionDesc);
 	}
 
 	@Override
@@ -94,7 +95,7 @@ public class AcknowledgeAlarmAction implements IObjectActionDelegate {
         }else
             return null;
     }
-    
+
     private static ImageDescriptor getImageDescriptor(BeastAlarmSeverityLevel currentSeverity, BeastAlarmSeverityLevel latchedSeverity) {
         AlarmIcons icons = AlarmIcons.getInstance();
         switch (latchedSeverity) {
@@ -103,16 +104,16 @@ public class AcknowledgeAlarmAction implements IObjectActionDelegate {
                 return icons.getInvalidAcknowledged(false);
             case UNDEFINED:
             case INVALID:
-                return currentSeverity == BeastAlarmSeverityLevel.OK ? icons.getInvalidClearedNotAcknowledged(false) : icons
-                        .getInvalidNotAcknowledged(false);
+                return currentSeverity == BeastAlarmSeverityLevel.OK ?
+                        icons.getInvalidClearedNotAcknowledged(false) : icons.getInvalidNotAcknowledged(false);
             case MAJOR:
-                return currentSeverity == BeastAlarmSeverityLevel.OK ? icons.getMajorClearedNotAcknowledged(false) : icons
-                        .getMajorNotAcknowledged(false);
+                return currentSeverity == BeastAlarmSeverityLevel.OK ?
+                        icons.getMajorClearedNotAcknowledged(false) : icons.getMajorNotAcknowledged(false);
             case MAJOR_ACK:
                 return icons.getMajorAcknowledged(false);
             case MINOR:
-                return currentSeverity == BeastAlarmSeverityLevel.OK ? icons.getMinorClearedNotAcknowledged(false) : icons
-                        .getMinorNotAcknowledged(false);
+                return currentSeverity == BeastAlarmSeverityLevel.OK ?
+                        icons.getMinorClearedNotAcknowledged(false) : icons.getMinorNotAcknowledged(false);
             case MINOR_ACK:
                 return icons.getMinorAcknowledged(false);
             case OK:
@@ -120,5 +121,5 @@ public class AcknowledgeAlarmAction implements IObjectActionDelegate {
                 return null;
         }
     }
-	
+
 }

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/PVWidgetEditpartDelegate.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/editparts/PVWidgetEditpartDelegate.java
@@ -167,9 +167,11 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
     // (secondary) PV on which we listen for BEAST events
     private PV<?, Object> alarmPV = null;
     private boolean isBeastAlarm = false;
+    private boolean isBeastAlarmNode = false; // is this an Alarm Node instead of a PV ?
     private BeastAlarmInfo beastInfo = new BeastAlarmInfo();
 
-    /**Returns true when:
+    /**
+     * @return <code>true</code> when:<br>
      * - BEAST Alarm functionality is enabled and the BeastAlarmListener is connected to the BeastDataSource<br>
      * - Widget's PV was found (== defined in BEAST)
      */
@@ -199,6 +201,14 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
 
     public BeastAlarmInfo getBeastAlarmInfo() {
         return beastInfo;
+    }
+
+    /**
+     * @return <code>true</code> if this widget's PVName is actually a BEAST Alarm node,<br>
+     *         <code>false</code> if it's a PV (or not a BeastAlarm - also check {@link #isBeastAlarmAndConnected})
+     */
+    public boolean isBeastAlarmNode() {
+        return isBeastAlarmNode;
     }
 
 
@@ -312,12 +322,14 @@ public class PVWidgetEditpartDelegate implements IPVWidgetEditpart {
         if (alarmPVName.equals("")) {
             alarmPV = null;
             isBeastAlarm = false;
+            isBeastAlarmNode = false;
             beastInfo.setBeastChannelConnected(false);
             return;
         }
 
 //        log.fine("Starting BeastAlarmListener for channel " + alarmPVName);
         beastInfo.setBeastChannelName(alarmPVName);
+        isBeastAlarmNode = getPVName().toLowerCase().startsWith("beast://");
         PVWidgetEditpartDelegate pvWidget = this;
 
         DesiredRateReadWriteExpression<?,Object> expr = formula(alarmPVName);

--- a/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/BeastAlarmInfo.java
+++ b/applications/opibuilder/opibuilder-plugins/org.csstudio.opibuilder/src/org/csstudio/opibuilder/util/BeastAlarmInfo.java
@@ -10,7 +10,7 @@ package org.csstudio.opibuilder.util;
 import org.diirt.vtype.AlarmSeverity;
 
 /** BEAST alarm info for PV Widgets.
- *  
+ *
  * @author Boris Versic
  */
 public final class BeastAlarmInfo {
@@ -39,8 +39,14 @@ public final class BeastAlarmInfo {
         return alarmPVChannelName;
     }
 
+    public String getBeastChannelNameNoScheme() {
+        if (alarmPVChannelName.length() > 8)
+            return alarmPVChannelName.substring(8);
+        return "";
+    }
+
     /** @return <code>true</code> if (latched) severity indicates an acknowledged state,
-     *          <code>false</code> for unacknowledged alarm or OK 
+     *          <code>false</code> for unacknowledged alarm or OK
      */
     public boolean isAcknowledged() {
         return !latchedSeverity.isActive() && latchedSeverity != BeastAlarmSeverityLevel.OK;
@@ -52,7 +58,7 @@ public final class BeastAlarmInfo {
     public boolean isLatchedAlarmActive() {
         return latchedSeverity.isActive();
     }
-    
+
     /** @return <code>true</code> if (current) severity indicates an active alarm,
      *          <code>false</code> for acknowledged or OK state
      */


### PR DESCRIPTION
BEAST acknowledgment in context menu moved to submenu (for adding alarm time etc later), added distinction between Alarm Tree Node vs. PV
